### PR TITLE
feature/detect theme config fix: Updated method to know mac theme

### DIFF
--- a/src/pages/config/Options/Options.js
+++ b/src/pages/config/Options/Options.js
@@ -10,7 +10,7 @@ import WallpaperManager from '../../../utils/wallpapermanager';
 import Template from './Options.jsx';
 import './Options.scss';
 
-const { systemPreferences } = window.require("electron").remote;
+const { nativeTheme } = window.require("electron").remote;
 
 const ALL_PROVIDERS = WallpaperManager.getAllProviders();
 
@@ -45,7 +45,7 @@ const Config = ({ config, setProperties, resetConfig }) => {
 		let properties = { autoDetectTheme: value };
 
 		if(value)
-			properties.darkTheme = systemPreferences.isDarkMode();
+			properties.darkTheme = nativeTheme.shouldUseDarkColors
 
 		setProperties(properties);
 	}

--- a/src/utils/windowmanager.js
+++ b/src/utils/windowmanager.js
@@ -3,7 +3,7 @@ import WallpaperManager from './wallpapermanager';
 import store from '../store';
 import { setProperties } from '../actions/config';
 
-const { app, systemPreferences, globalShortcut } = window.require('electron').remote;
+const { app, systemPreferences, nativeTheme, globalShortcut } = window.require('electron').remote;
 const autoLaunch = window.require("auto-launch");
 
 export default class WindowManager{
@@ -54,7 +54,7 @@ export default class WindowManager{
 		        let allowAutoChange = store.getState().config.autoDetectTheme;
 
 		        if(allowAutoChange)
-		            store.dispatch(setProperties({ darkTheme: systemPreferences.isDarkMode() }));
+		            store.dispatch(setProperties({ darkTheme: nativeTheme.shouldUseDarkColors }));
 		    }
 		)
 	}


### PR DESCRIPTION
- Updated pre-deprecated method systemPreferences.isDarkMode()